### PR TITLE
feat: add basic health check and modernize UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -205,3 +205,5 @@ cython_debug/
 marimo/_static/
 marimo/_lsp/
 __marimo__/
+!frontend/src/lib/
+!frontend/src/lib/**

--- a/frontend/src/components/AgentForm.tsx
+++ b/frontend/src/components/AgentForm.tsx
@@ -17,9 +17,18 @@ export default function AgentForm() {
 
   return (
     <div>
-      <input value={name} onChange={(e) => setName(e.target.value)} placeholder="name" />
-      <textarea value={config} onChange={(e) => setConfig(e.target.value)} />
-      <button onClick={submit}>Create</button>
+      <input
+        value={name}
+        onChange={(e) => setName(e.target.value)}
+        placeholder="name"
+        title="Enter a unique agent name"
+      />
+      <textarea
+        value={config}
+        onChange={(e) => setConfig(e.target.value)}
+        title="Provide JSON configuration for the agent"
+      />
+      <button onClick={submit} title="Submit the agent configuration">Create</button>
     </div>
   );
 }

--- a/frontend/src/components/HealthCheck.tsx
+++ b/frontend/src/components/HealthCheck.tsx
@@ -1,0 +1,22 @@
+import { useState } from 'react';
+import { getHealth } from '../lib/api';
+
+export default function HealthCheck() {
+  const [status, setStatus] = useState<string | null>(null);
+
+  const check = async () => {
+    try {
+      const res = await getHealth();
+      setStatus(res.status);
+    } catch (e) {
+      setStatus('error');
+    }
+  };
+
+  return (
+    <div className="card">
+      <button onClick={check} title="Verify backend connection">Check API health</button>
+      {status && <p>API status: {status}</p>}
+    </div>
+  );
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,0 +1,23 @@
+const API_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
+
+export async function listRuns() {
+  const res = await fetch(`${API_URL}/runs`);
+  if (!res.ok) throw new Error('Failed to fetch runs');
+  return res.json();
+}
+
+export async function createAgent(agent: { name: string; config: any }) {
+  const res = await fetch(`${API_URL}/agents`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(agent),
+  });
+  if (!res.ok) throw new Error('Failed to create agent');
+  return res.json();
+}
+
+export async function getHealth() {
+  const res = await fetch(`${API_URL}/health`);
+  if (!res.ok) throw new Error('Health check failed');
+  return res.json();
+}

--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -1,9 +1,11 @@
 import Layout from '../components/Layout';
+import HealthCheck from '../components/HealthCheck';
 
 export default function IndexPage() {
   return (
     <Layout>
       <h1>Dashboard</h1>
+      <HealthCheck />
     </Layout>
   );
 }

--- a/frontend/styles/globals.css
+++ b/frontend/styles/globals.css
@@ -1,2 +1,7 @@
-body { font-family: sans-serif; margin: 0; padding: 1rem; }
-nav a { margin-right: 1rem; }
+body { font-family: sans-serif; margin: 0; padding: 1rem; background: #f5f5f5; }
+nav { background: #333; padding: 0.5rem; }
+nav a { margin-right: 1rem; color: #fff; text-decoration: none; }
+main { margin-top: 1rem; }
+button { padding: 0.5rem 1rem; border: none; background: #0070f3; color: #fff; border-radius: 4px; cursor: pointer; }
+button:hover { background: #005bb5; }
+.card { border: 1px solid #ddd; padding: 1rem; border-radius: 4px; background: #fff; }

--- a/frontend/tests/smoke.spec.ts
+++ b/frontend/tests/smoke.spec.ts
@@ -3,4 +3,5 @@ import { test, expect } from '@playwright/test';
 test('index', async ({ page }) => {
   await page.goto('http://localhost:3000');
   await expect(page.locator('h1')).toContainText('Dashboard');
+  await expect(page.getByRole('button', { name: /check api health/i })).toBeVisible();
 });

--- a/frontend/tests/smoke.test.tsx
+++ b/frontend/tests/smoke.test.tsx
@@ -1,7 +1,8 @@
 import { render, screen } from '@testing-library/react';
 import IndexPage from '../src/pages/index';
 
-test('renders dashboard', () => {
+test('renders dashboard with health check', () => {
   render(<IndexPage />);
   expect(screen.getByText('Dashboard')).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: /check api health/i })).toBeInTheDocument();
 });


### PR DESCRIPTION
## Summary
- add shared API helper and health check component
- modernize styling and add tooltips for clarity
- update smoke tests for new UI

## Testing
- `make test` (fails: ModuleNotFoundError: No module named 'fastapi')
- `npm --prefix frontend test` (fails: jest: not found)


------
https://chatgpt.com/codex/tasks/task_e_68c76b09164c83229ed08b4ed9ab0152