### PR TITLE
Add landing page for root endpoint

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,4 +1,5 @@
 from fastapi import FastAPI
+from fastapi.responses import HTMLResponse
 
 from .api.v1 import agents, approvals, connectors, health, rag, runs, tools
 from .core import audit
@@ -12,6 +13,18 @@ except Exception:
 
 app = FastAPI(title="Agentic Platform")
 app.middleware("http")(audit.audit_middleware)
+
+
+@app.get("/", include_in_schema=False)
+async def root() -> HTMLResponse:
+    """Serve a simple landing page so the app isn't 404 at root."""
+    html_content = (
+        "<html><head><title>Agentic Platform API</title></head>"
+        "<body><h1>Agentic Platform API</h1>"
+        "<p>Visit <a href='/docs'>/docs</a> for API documentation.</p>"
+        "</body></html>"
+    )
+    return HTMLResponse(content=html_content)
 
 app.include_router(health.router)
 app.include_router(agents.router)

--- a/backend/tests/test_root.py
+++ b/backend/tests/test_root.py
@@ -1,0 +1,11 @@
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+client = TestClient(app)
+
+
+def test_root_serves_landing_page():
+    resp = client.get("/")
+    assert resp.status_code == 200
+    assert "Agentic Platform API" in resp.text


### PR DESCRIPTION
## Summary
- serve simple HTML landing page at `/` to avoid 404s
- add test ensuring root endpoint returns the landing page

## Testing
- `DATABASE_URL=sqlite:///./test.db PYTHONPATH=. pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c7742c0e548322bd3cfc7290e76e51